### PR TITLE
Update plugin for Folia 1.21 and scheduler thread safety

### DIFF
--- a/useTranslatedNames-2.3.1-Folia/pom.xml
+++ b/useTranslatedNames-2.3.1-Folia/pom.xml
@@ -11,7 +11,7 @@
 <name>useTranslatedNames</name>
 
 <properties>
-    <java.version>1.8</java.version>
+    <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 </properties>
 
@@ -23,8 +23,7 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <version>3.11.0</version>
             <configuration>
-                <source>14</source>
-                <target>14</target>
+                <release>21</release>
             </configuration>
         </plugin>
     </plugins>
@@ -42,6 +41,10 @@
         <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
     </repository>
     <repository>
+        <id>papermc-repo</id>
+        <url>https://repo.papermc.io/repository/maven-public/</url>
+    </repository>
+    <repository>
         <id>dmulloy2-repo</id>
         <url>https://repo.dmulloy2.net/repository/public/</url>
     </repository>
@@ -49,15 +52,15 @@
 
 <dependencies>
     <dependency>
-        <groupId>org.spigotmc</groupId>
-        <artifactId>spigot-api</artifactId>
-        <version>1.16.5-R0.1-SNAPSHOT</version>
+        <groupId>dev.folia</groupId>
+        <artifactId>folia-api</artifactId>
+        <version>1.21.1-R0.1-SNAPSHOT</version>
         <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>com.comphenix.protocol</groupId>
         <artifactId>ProtocolLib</artifactId>
-        <version>5.1.0</version>
+        <version>5.3.0</version>
         <scope>provided</scope>
     </dependency>
 </dependencies>


### PR DESCRIPTION
## Summary
- Build against Folia API 1.21.1 and Java 21
- Update ProtocolLib dependency
- Use Folia global/player schedulers instead of asynchronous threads in chat handler

## Testing
- `mvn -q package -DskipTests` *(fails: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689beb31a4a883319ad105a3d4feffe4